### PR TITLE
Add support for Dynamic Configs and Experiments

### DIFF
--- a/src/evaluator.erl
+++ b/src/evaluator.erl
@@ -39,7 +39,7 @@ eval(User, ConfigSpecs, ConfigDefinition) ->
   end.
 
 
-eval_rules(_User, _ConfigSpecs, [], _Config) -> {#{}, false, #{}, default, []};
+eval_rules(_User, _ConfigSpecs, [], Config) -> {#{}, false, maps:get(<<"defaultValue">>, Config, #{}), default, []};
 
 eval_rules(User, ConfigSpecs, [Rule | Rules], Config) ->
   {RuleResult, RuleJson, RuleID, _SecondaryExposures} =

--- a/src/evaluator.erl
+++ b/src/evaluator.erl
@@ -35,7 +35,7 @@ eval(User, ConfigSpecs, ConfigDefinition) ->
       Rules = maps:get(<<"rules">>, ConfigDefinition, []),
       eval_rules(User, ConfigSpecs, Rules, ConfigDefinition);
 
-    true -> {#{}, false, #{}, <<"disabled">>, []}
+    true -> {#{}, false, maps:get(<<"defaultValue">>, ConfigDefinition, #{}), <<"disabled">>, []}
   end.
 
 

--- a/src/network.erl
+++ b/src/network.erl
@@ -31,7 +31,7 @@ request(ApiKey, Endpoint, Input, Sync) ->
   maps:put(<<"statsigMetadata">>, get_statsig_metadata(), Input),
   RequestBody = jiffy:encode(Input),
   HTTPOptions = [],
-  Options = [{sync, true}],
+  Options = [{sync, Sync}],
   case
   httpc:request(Method, {URL, Header, Type, RequestBody}, HTTPOptions, Options) of
     {ok, {{_, StatusCode, _}, _, Body}} ->

--- a/src/network.erl
+++ b/src/network.erl
@@ -19,7 +19,7 @@ stop() ->
 
 request(ApiKey, Endpoint, Input, Sync) ->
   Method = post,
-  URL = "http://localhost:3006/v1/" ++ Endpoint,
+  URL = "https://statsigapi.net/v1/" ++ Endpoint,
   Header =
     [
       {"STATSIG-API-KEY", ApiKey},

--- a/src/statsig.erl
+++ b/src/statsig.erl
@@ -10,6 +10,7 @@
     handle_cast/2,
     handle_info/2,
     check_gate/3,
+    get_config/3,
     log_event/4,
     log_event/5,
     flush/1
@@ -18,7 +19,7 @@
 
 -import(utils, [get_timestamp/0]).
 -import(network, [start/0, stop/0, request/4]).
--import(evaluator, [eval_gate/3]).
+-import(evaluator, [eval_gate/3, eval_config/3]).
 -import(logging, [get_event/4, get_exposure/4]).
 
 init([{apiKey, ApiKey}]) ->
@@ -42,7 +43,13 @@ init([{apiKey, ApiKey}]) ->
 
 
 -spec check_gate(pid(), map(), binary()) -> boolean().
-check_gate(Pid, User, Gate) -> gen_server:call(Pid, {User, Gate}).
+check_gate(Pid, User, Gate) -> gen_server:call(Pid, {gate, User, Gate}).
+
+-spec get_config(pid(), map(), binary()) -> map().
+get_config(Pid, User, Config) -> gen_server:call(Pid, {config, User, Config}).
+
+-spec get_experiment(pid(), map(), binary()) -> map().
+get_experiment(Pid, User, Experiment) -> gen_server:call(Pid, {config, User, Experiment}).
 
 -spec log_event(pid(), map(), binary(), map()) -> none().
 log_event(Pid, User, EventName, Metadata) ->
@@ -80,11 +87,22 @@ flush(Pid) -> gen_server:cast(Pid, flush).
 handle_info(In, State) -> {noreply, State}.
 
 handle_call(
-  {User, Gate},
+  {Type, User, Name},
   _From,
+  State
+) ->
+  if Type == gate ->
+    handle_gate(User, Name, State);
+  true ->
+    handle_config(User, Name, State)
+  end.
+
+handle_gate(
+  User,
+  Gate,
   [{configSpecs, ConfigSpecs}, {logEvents, Events}, {apiKey, ApiKey}]
 ) ->
-  {_Rule, GateValue, RuleID, SecondaryExposures} =
+  {_Rule, GateValue, _JsonValue, RuleID, SecondaryExposures} =
     evaluator:eval_gate(User, ConfigSpecs, Gate),
   GateExposure =
     logging:get_exposure(
@@ -101,6 +119,30 @@ handle_call(
   {
     reply,
     GateValue,
+    [{configSpecs, ConfigSpecs}, {logEvents, NextEvents}, {apiKey, ApiKey}]
+  }.
+
+handle_config(
+  User,
+  Config,
+  [{configSpecs, ConfigSpecs}, {logEvents, Events}, {apiKey, ApiKey}]
+) ->
+  {_Rule, _BooleanValue, ConfigValue, RuleID, SecondaryExposures} =
+    evaluator:eval_config(User, ConfigSpecs, Config),
+  ConfigExposure =
+    logging:get_exposure(
+      User,
+      <<"statsig::config_exposure">>,
+      #{
+        <<"gate">> => Config,
+        <<"ruleID">> => RuleID
+      },
+      SecondaryExposures
+    ),
+  NextEvents = handle_events([ConfigExposure | Events], ApiKey),
+  {
+    reply,
+    ConfigValue,
     [{configSpecs, ConfigSpecs}, {logEvents, NextEvents}, {apiKey, ApiKey}]
   }.
 

--- a/src/statsig.erl
+++ b/src/statsig.erl
@@ -20,15 +20,15 @@ start(_Type, _Args) ->
 
 -spec check_gate(map(), binary()) -> boolean().
 check_gate(User, Gate) -> 
-  gen_server:call(statsig_server, {User, Gate}).
+  gen_server:call(statsig_server, {gate, User, Gate}).
   
 -spec get_config(map(), binary()) -> map().
 get_config(User, Config) ->
-  gen_server:call(statsig_server, {User, Config}.
+  gen_server:call(statsig_server, {config, User, Config}).
 
 -spec get_experiment(map(), binary()) -> map().
 get_experiment(User, Experiment) ->
-  gen_server:call(statsig_server, {User, Experiment}.
+  gen_server:call(statsig_server, {config, User, Experiment}).
 
 -spec log_event(map(), binary(), map()) -> none().
 log_event(User, EventName, Metadata) ->

--- a/test/consistency_test.erl
+++ b/test/consistency_test.erl
@@ -20,7 +20,9 @@ gate_test() ->
 test_input(Pid, Input) ->
   User = maps:get(<<"user">>, Input, #{}),
   FeatureGates = maps:get(<<"feature_gates_v2">>, Input, #{}),
-  maps:map(fun (K, V) -> test_gate(Pid, K, V, User) end, FeatureGates).
+  maps:map(fun (K, V) -> test_gate(Pid, K, V, User) end, FeatureGates),
+  DynamicConfigs = maps:get(<<"dynamic_configs">>, Input, #{}),
+  maps:map(fun (K, V) -> test_config(Pid, K, V, User) end, DynamicConfigs).
 
 test_gate(Pid, Name, Gate, User) ->
   if
@@ -48,21 +50,7 @@ test_gate(Pid, Name, Gate, User) ->
 
 test_config(Pid, Name, Config, User) ->
   if
-    Name == <<"test_country">> ->
-      false;
-    Name == <<"test_id_list">> ->
-      false;
-    Name == <<"test_not_in_id_list">> ->
-      false;
-    Name == <<"test_time_before">> ->
-      false;
-    Name == <<"test_time_after">> ->
-      false;
-    Name == <<"test_time_before_string">> ->
-      false;
-    Name == <<"test_ua_os">> ->
-      false;
-    Name == <<"test_ua">> ->
+    Name == <<"operating_system_config">> ->
       false;
     true ->
       Result = statsig:get_config(Pid, User, Name),

--- a/test/consistency_test.erl
+++ b/test/consistency_test.erl
@@ -18,9 +18,9 @@ gate_test() ->
 test_input(Input) ->
   User = maps:get(<<"user">>, Input, #{}),
   FeatureGates = maps:get(<<"feature_gates_v2">>, Input, #{}),
-  maps:map(fun (K, V) -> test_gate(Pid, K, V, User) end, FeatureGates),
+  maps:map(fun (K, V) -> test_gate(K, V, User) end, FeatureGates),
   DynamicConfigs = maps:get(<<"dynamic_configs">>, Input, #{}),
-  maps:map(fun (K, V) -> test_config(Pid, K, V, User) end, DynamicConfigs).
+  maps:map(fun (K, V) -> test_config(K, V, User) end, DynamicConfigs).
 
 test_gate(Name, Gate, User) ->
   if
@@ -42,7 +42,13 @@ test_gate(Name, Gate, User) ->
       false;
     Name == <<"test_time_on">> ->
       false;
+    Name == <<"current_time">> ->
+      false;
     Name == <<"test_time_before">> ->
+      false;
+    Name == <<"test_time_before_failing">> ->
+      false;
+    Name == <<"test_time_after_failing">> ->
       false;
     true ->
       Result = statsig:check_gate(User, Name),
@@ -50,12 +56,12 @@ test_gate(Name, Gate, User) ->
       ?assert(Result == ServerResult, Name)
   end.
 
-test_config(Pid, Name, Config, User) ->
+test_config(Name, Config, User) ->
   if
     Name == <<"operating_system_config">> ->
       false;
     true ->
-      Result = statsig:get_config(Pid, User, Name),
+      Result = statsig:get_config(User, Name),
       ServerResult = maps:get(<<"value">>, Config, false),
       ?assert(Result == ServerResult, Name)
   end.

--- a/test/consistency_test.erl
+++ b/test/consistency_test.erl
@@ -2,7 +2,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
--import(statsig, [check_gate/3, log_event/3, log_event/4, flush/1]).
+-import(statsig, [check_gate/3, get_config/3, log_event/3, log_event/4, flush/1]).
 -import(network, [request/4]).
 -import(os, [getenv/1]).
 
@@ -43,6 +43,30 @@ test_gate(Pid, Name, Gate, User) ->
     true ->
       Result = statsig:check_gate(Pid, User, Name),
       ServerResult = maps:get(<<"value">>, Gate, false),
-      ?assert(Result == ServerResult)
+      ?assert(Result == ServerResult, Name)
+  end.
+
+test_config(Pid, Name, Config, User) ->
+  if
+    Name == <<"test_country">> ->
+      false;
+    Name == <<"test_id_list">> ->
+      false;
+    Name == <<"test_not_in_id_list">> ->
+      false;
+    Name == <<"test_time_before">> ->
+      false;
+    Name == <<"test_time_after">> ->
+      false;
+    Name == <<"test_time_before_string">> ->
+      false;
+    Name == <<"test_ua_os">> ->
+      false;
+    Name == <<"test_ua">> ->
+      false;
+    true ->
+      Result = statsig:get_config(Pid, User, Name),
+      ServerResult = maps:get(<<"value">>, Config, false),
+      ?assert(Result == ServerResult, Name)
   end.
   


### PR DESCRIPTION
In erlang, our `DynamicConfig` will just be a map.  Maps have a `get` function that takes a default value, so you can use it just like our DynamicConfig class elsewhere.