### PR TITLE
Cleanup api, separate statsig_server, fix app

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ Run
 -----
     $ rebar3 shell --apps statsig
 
-% Usage:
-% {ok, Pid} = gen_server:start(statsig, [{apiKey, ""}], []). 
-% statsig:check_gate(Pid, #{<<"userID">> => <<"1234">>}, <<"test">>).
-% statsig:check_gate(Pid, #{<<"userID">> => <<"12345">>}, <<"test">>).
-% statsig:log_event(Pid, #{<<"userID">> => <<"12345">>}, <<"custom_event">>, <<"custom_value">>, #{<<"test">> => <<"val">>}).
-% statsig:flush(Pid).
+## Usage:
+```
+application:set_env(statsig, statsig_api_key, ApiKey),
+application:start(statsig),
+statsig:check_gate(User, GateName),
+statsig:log_event(#{<<"userID">> => <<"321">>}, <<"custom_event">>, 12, #{<<"test">> => <<"val">>}),
+statsig:flush(Pid).
+```

--- a/src/evaluator.erl
+++ b/src/evaluator.erl
@@ -98,10 +98,25 @@ get_evaluation_comparison(Condition, Value) ->
 
 compare(Value, Operator, Target) ->
   case Operator of
-    <<"gt">> -> Value > Target;
-    <<"gte">> -> Value >= Target;
-    <<"lt">> -> Value < Target;
-    <<"lte">> -> Value =< Target;
+    <<"gt">> -> 
+      if
+        Value == unknown -> false;
+        true -> Value > Target
+      end;
+    <<"gte">> ->
+      if
+        Value == unknown -> false;
+        true -> Value >= Target
+      end;
+    <<"lt">> ->
+      if
+        Value == unknown -> false;
+        true -> Value < Target
+      end;
+    <<"lte">> ->if
+        Value == unknown -> false;
+        true -> Value =< Target
+      end;
 
     <<"version_gt">> ->
       if

--- a/src/logging.erl
+++ b/src/logging.erl
@@ -3,24 +3,20 @@
 -export([get_event/4]).
 -export([get_exposure/4]).
 
--import(utils, [get_timestamp/0]).
-
 get_event(User, EventName, Value, Metadata) ->
   Event =
     #{
       <<"eventName">> => EventName,
       <<"metadata">> => Metadata,
       <<"user">> => User,
-      <<"time">> => list_to_binary(get_timestamp())
+      <<"time">> => list_to_binary(utils:get_timestamp())
     },
   if
-    Value == undefined -> undefined;
+    Value == undefined -> Event;
     true -> maps:put(<<"value">>, Value, Event)
-  end,
-  Event.
+  end.
 
 
 get_exposure(User, EventName, Metadata, SecondaryExposures) ->
   Event = get_event(User, EventName, undefined, Metadata),
-  maps:put(<<"secondaryExposures">>, SecondaryExposures, Event),
-  Event.
+  maps:put(<<"secondaryExposures">>, SecondaryExposures, Event).

--- a/src/network.erl
+++ b/src/network.erl
@@ -1,46 +1,31 @@
 -module(network).
 
--export([start/0, stop/0, request/4]).
-
--import(
-  utils,
-  [get_timestamp/0, get_sdk_type/0, get_sdk_version/0, get_statsig_metadata/0]
-).
-
-start() ->
-  inets:start(),
-  ssl:start().
-
-
-stop() ->
-  inets:stop(),
-  ssl:stop().
-
+-export([request/4]).
 
 request(ApiKey, Endpoint, Input, Sync) ->
   Method = post,
-  URL = "http://localhost:3006/v1/" ++ Endpoint,
+  URL = application:get_env(statsig, statsig_api, "https://statsigapi.net/v1/"),
   Header =
     [
       {"STATSIG-API-KEY", ApiKey},
-      {"STATSIG-CLIENT-TIME", get_timestamp()},
-      {"STATSIG-SDK-TYPE", get_sdk_type()},
-      {"STATSIG-SDK-VERSION", get_sdk_version()}
+      {"STATSIG-CLIENT-TIME", utils:get_timestamp()},
+      {"STATSIG-SDK-TYPE", utils:get_sdk_type()},
+      {"STATSIG-SDK-VERSION", utils:get_sdk_version()}
     ],
   Type = "application/json",
-  maps:put(<<"statsigMetadata">>, get_statsig_metadata(), Input),
+  maps:put(<<"statsigMetadata">>, utils:get_statsig_metadata(), Input),
   RequestBody = jiffy:encode(Input),
   HTTPOptions = [],
-  Options = [{sync, true}],
+  Options = [{sync, Sync}],
   case
-  httpc:request(Method, {URL, Header, Type, RequestBody}, HTTPOptions, Options) of
+  httpc:request(Method, {URL ++ Endpoint, Header, Type, RequestBody}, HTTPOptions, Options) of
     {ok, {{_, StatusCode, _}, _, Body}} ->
       if
         StatusCode < 300 -> Body;
         true -> false
       end;
 
-    {ok, RequestId} -> true;
+    {ok, _RequestId} -> true;
     {error, _} -> false;
     true -> false
   end.

--- a/src/statsig.app.src
+++ b/src/statsig.app.src
@@ -2,12 +2,15 @@
  [{description, "Statsig SDK for erlang and elixir"},
   {vsn, "0.1.0"},
   {registered, []},
+  {mod, {statsig, []}},
   {applications,
    [kernel,
-    stdlib
+    stdlib,
+    inets,
+    ssl
    ]},
-  {env,[]},
-  {modules, []},
+  {env,[{statsig_api, "https://statsigapi.net/v1/"}]},
+  {modules, [gen_server]},
 
   {licenses, ["ISC"]},
   {links, []}

--- a/src/statsig.erl
+++ b/src/statsig.erl
@@ -1,140 +1,48 @@
 -module(statsig).
 
--behaviour(gen_server).
+-behaviour(application).
 
 -export(
   [
-    init/1,
-    terminate/2,
-    handle_call/3,
-    handle_cast/2,
-    handle_info/2,
-    check_gate/3,
+    start_link/0,
+    start/2,
+    stop/1,
+    check_gate/2,
+    log_event/3,
     log_event/4,
-    log_event/5,
-    flush/1
+    flush/0
   ]
 ).
 
--import(utils, [get_timestamp/0]).
--import(network, [start/0, stop/0, request/4]).
--import(evaluator, [eval_gate/3]).
--import(logging, [get_event/4, get_exposure/4]).
+start_link() ->
+  gen_server:start_link(?MODULE, [], []).
 
-init([{apiKey, ApiKey}]) ->
-  network:start(),
-  Body = network:request(ApiKey, "download_config_specs", #{}, true),
-  if
-    Body == false ->
-      network:stop(),
-      {stop, "Initialize Failed"};
+start(_Type, _Params) ->
+  {ok, ApiKey} = application:get_env(statsig, statsig_api_key),
+  {ok, Pid} = gen_server:start(statsig_server, [{api_key, ApiKey}], []),
+  register(statsigsdk, Pid).
 
-    true ->
-      {
-        ok,
-        [
-          {configSpecs, jiffy:decode(Body, [return_maps])},
-          {logEvents, []},
-          {apiKey, ApiKey}
-        ]
-      }
-  end.
+-spec check_gate(map(), binary()) -> boolean().
+check_gate(User, Gate) -> 
+  Pid = whereis(statsigsdk),
+  gen_server:call(Pid, {User, Gate}).
 
-
--spec check_gate(pid(), map(), binary()) -> boolean().
-check_gate(Pid, User, Gate) -> gen_server:call(Pid, {User, Gate}).
-
--spec log_event(pid(), map(), binary(), map()) -> none().
-log_event(Pid, User, EventName, Metadata) ->
+-spec log_event(map(), binary(), map()) -> none().
+log_event(User, EventName, Metadata) ->
+  Pid = whereis(statsigsdk),
   gen_server:cast(Pid, {log, User, EventName, undefined, Metadata}).
 
--spec log_event(pid(), map(), binary(), binary() | number(), map()) -> none().
-log_event(Pid, User, EventName, Value, Metadata) ->
+-spec log_event(map(), binary(), binary() | number(), map()) -> none().
+log_event(User, EventName, Value, Metadata) ->
+  Pid = whereis(statsigsdk),
   gen_server:cast(Pid, {log, User, EventName, Value, Metadata}).
 
-handle_cast(
-  {log, User, EventName, Value, Metadata},
-  [{configSpecs, ConfigSpecs}, {logEvents, Events}, {apiKey, ApiKey}]
-) ->
-  Event = logging:get_event(User, EventName, Value, Metadata),
-  {
-    noreply,
-    [
-      {configSpecs, ConfigSpecs},
-      {logEvents, [Event | Events]},
-      {apiKey, ApiKey}
-    ]
-  };
-
-handle_cast(
-  flush,
-  [{configSpecs, _ConfigSpecs}, {logEvents, Events}, {apiKey, ApiKey}]
-) ->
-  flush_events(ApiKey, Events),
-  {noreply, [{configSpecs, _ConfigSpecs}, {logEvents, []}, {apiKey, ApiKey}]}.
-
-
--spec flush(pid()) -> none().
-flush(Pid) -> gen_server:cast(Pid, flush).
-
-handle_info(In, State) -> {noreply, State}.
-
-handle_call(
-  {User, Gate},
-  _From,
-  [{configSpecs, ConfigSpecs}, {logEvents, Events}, {apiKey, ApiKey}]
-) ->
-  {_Rule, GateValue, RuleID, SecondaryExposures} =
-    evaluator:eval_gate(User, ConfigSpecs, Gate),
-  GateExposure =
-    logging:get_exposure(
-      User,
-      <<"statsig::gate_exposure">>,
-      #{
-        <<"gate">> => Gate,
-        <<"gateValue">> => GateValue,
-        <<"ruleID">> => RuleID
-      },
-      SecondaryExposures
-    ),
-  NextEvents = handle_events([GateExposure | Events], ApiKey),
-  {
-    reply,
-    GateValue,
-    [{configSpecs, ConfigSpecs}, {logEvents, NextEvents}, {apiKey, ApiKey}]
-  }.
-
-
-flush_events(ApiKey, Events) ->
-  Input = #{<<"events">> => Events},
-  network:request(ApiKey, "rgstr", Input, false) /= false.
-
-
-handle_events(Events, ApiKey) ->
-  if
-    length(Events) > 999 ->
-      % We've been failing to post events for too long
-      % lets keep the most recent 500 events
-      lists:sublist(Events, 499);
-
-    length(Events) > 499 ->
-      Success = flush_events(ApiKey, Events),
-      if
-        Success -> [];
-        true -> Events
-      end;
-
-    true -> Events
-  end.
-
-
-terminate(
-  _Reason,
-  [{configSpecs, _ConfigSpecs}, {logEvents, Events}, {apiKey, ApiKey}]
-) ->
-  if
-    length(Events) > 0 -> flush_events(ApiKey, Events);
-    true -> false
-  end,
-  network:stop(),
+-spec flush() -> none().
+flush() -> 
+  Pid = whereis(statsigsdk),
+  gen_server:cast(Pid, flush).
+  
+stop(_State) ->
+  Pid = whereis(statsigsdk),
+  gen_server:stop(Pid),
   ok.

--- a/src/statsig.erl
+++ b/src/statsig.erl
@@ -4,7 +4,6 @@
 
 -export(
   [
-    start_link/0,
     start/2,
     stop/1,
     check_gate/2,
@@ -14,35 +13,25 @@
   ]
 ).
 
-start_link() ->
-  gen_server:start_link(?MODULE, [], []).
 
-start(_Type, _Params) ->
-  {ok, ApiKey} = application:get_env(statsig, statsig_api_key),
-  {ok, Pid} = gen_server:start(statsig_server, [{api_key, ApiKey}], []),
-  register(statsigsdk, Pid).
+start(_Type, _Args) ->
+  statsig_sup:start_link().
 
 -spec check_gate(map(), binary()) -> boolean().
 check_gate(User, Gate) -> 
-  Pid = whereis(statsigsdk),
-  gen_server:call(Pid, {User, Gate}).
+  gen_server:call(statsig_server, {User, Gate}).
 
 -spec log_event(map(), binary(), map()) -> none().
 log_event(User, EventName, Metadata) ->
-  Pid = whereis(statsigsdk),
-  gen_server:cast(Pid, {log, User, EventName, undefined, Metadata}).
+  gen_server:cast(statsig_server, {log, User, EventName, undefined, Metadata}).
 
 -spec log_event(map(), binary(), binary() | number(), map()) -> none().
 log_event(User, EventName, Value, Metadata) ->
-  Pid = whereis(statsigsdk),
-  gen_server:cast(Pid, {log, User, EventName, Value, Metadata}).
+  gen_server:cast(statsig_server, {log, User, EventName, Value, Metadata}).
 
 -spec flush() -> none().
 flush() -> 
-  Pid = whereis(statsigsdk),
-  gen_server:cast(Pid, flush).
+  gen_server:cast(statsig_server, flush).
   
 stop(_State) ->
-  Pid = whereis(statsigsdk),
-  gen_server:stop(Pid),
   ok.

--- a/src/statsig_server.erl
+++ b/src/statsig_server.erl
@@ -4,7 +4,7 @@
 
 -export(
   [
-    start_link/0,
+    start_link/1,
     init/1,
     terminate/2,
     handle_call/3,
@@ -13,17 +13,14 @@
   ]
 ).
 
-start_link() ->
-  gen_server:start_link(?MODULE, [], []).
+start_link(ApiKey) ->
+  gen_server:start_link({local,?MODULE}, ?MODULE, [ApiKey], []).
 
-init([{api_key, ApiKey}]) ->
-  erlang:display(ApiKey),
-  Body = network:request(ApiKey, "download_config_specs", #{}, true),
-  if
-    Body == false ->
+init([ApiKey]) ->
+  case network:request(ApiKey, "download_config_specs", #{}, true) of
+    false ->
       {stop, "Initialize Failed"};
-
-    true ->
+    Body ->
       {
         ok,
         [

--- a/src/statsig_server.erl
+++ b/src/statsig_server.erl
@@ -1,0 +1,117 @@
+-module(statsig_server).
+
+-behaviour(gen_server).
+
+-export(
+  [
+    start_link/0,
+    init/1,
+    terminate/2,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2
+  ]
+).
+
+start_link() ->
+  gen_server:start_link(?MODULE, [], []).
+
+init([{api_key, ApiKey}]) ->
+  erlang:display(ApiKey),
+  Body = network:request(ApiKey, "download_config_specs", #{}, true),
+  if
+    Body == false ->
+      {stop, "Initialize Failed"};
+
+    true ->
+      {
+        ok,
+        [
+          {config_specs, jiffy:decode(Body, [return_maps])},
+          {log_events, []},
+          {api_key, ApiKey}
+        ]
+      }
+  end.
+
+handle_cast(
+  {log, User, EventName, Value, Metadata},
+  [{config_specs, _ConfigSpecs}, {log_events, Events}, {api_key, ApiKey}]
+) ->
+  Event = logging:get_event(User, EventName, Value, Metadata),
+  {
+    noreply,
+    [
+      {config_specs, _ConfigSpecs},
+      {log_events, [Event | Events]},
+      {api_key, ApiKey}
+    ]
+  };
+
+handle_cast(
+  flush,
+  [{config_specs, _ConfigSpecs}, {log_events, Events}, {api_key, ApiKey}]
+) ->
+  flush_events(api_key, Events),
+  {noreply, [{config_specs, _ConfigSpecs}, {log_events, []}, {api_key, ApiKey}]}.
+
+handle_info(_In, State) -> {noreply, State}.
+
+handle_call(
+  {User, Gate},
+  _From,
+  [{config_specs, ConfigSpecs}, {log_events, Events}, {api_key, ApiKey}]
+) ->
+  {_Rule, GateValue, RuleID, SecondaryExposures} =
+    evaluator:eval_gate(User, ConfigSpecs, Gate),
+  GateExposure =
+    logging:get_exposure(
+      User,
+      <<"statsig::gate_exposure">>,
+      #{
+        <<"gate">> => Gate,
+        <<"gateValue">> => GateValue,
+        <<"ruleID">> => RuleID
+      },
+      SecondaryExposures
+    ),
+  NextEvents = handle_events([GateExposure | Events], ApiKey),
+  {
+    reply,
+    GateValue,
+    [{config_specs, ConfigSpecs}, {log_events, NextEvents}, {api_key, ApiKey}]
+  }.
+
+
+flush_events(ApiKey, Events) ->
+  Input = #{<<"events">> => Events},
+  network:request(ApiKey, "rgstr", Input, false) /= false.
+
+
+handle_events(Events, ApiKey) ->
+  if
+    length(Events) > 999 ->
+      % We've been failing to post events for too long
+      % lets keep the most recent 500 events
+      lists:sublist(Events, 499);
+
+    length(Events) > 499 ->
+      Success = flush_events(ApiKey, Events),
+      if
+        Success -> [];
+        true -> Events
+      end;
+
+    true -> Events
+  end.
+
+
+terminate(
+  _Reason,
+  [{config_specs, _config_specs}, {log_events, Events}, {api_key, ApiKey}]
+) ->
+  if
+    length(Events) > 0 -> flush_events(ApiKey, Events);
+    true -> false
+  end,
+  ok.

--- a/src/statsig_sup.erl
+++ b/src/statsig_sup.erl
@@ -1,0 +1,25 @@
+-module(statsig_sup).
+
+-behaviour(supervisor).
+
+-export([start_link/0]).
+-export([init/1, shutdown/0]).
+ 
+start_link() ->
+  supervisor:start_link({local,?MODULE}, ?MODULE, []).
+ 
+init([]) ->
+  case application:get_env(statsig, statsig_api_key) of
+    {ok, ApiKey} ->
+      RestartStrategy = {one_for_one, 10, 60},
+      Server = {stasig_serv,
+        {statsig_server, start_link, [ApiKey]},
+        permanent, infinity, worker, [statsig_server]},
+      Children = [Server],
+      {ok, {RestartStrategy, Children}};
+    Other ->
+      {error, Other}
+  end.
+
+shutdown() ->
+     exit(whereis(?MODULE), shutdown).

--- a/src/utils.erl
+++ b/src/utils.erl
@@ -17,4 +17,4 @@ get_statsig_metadata() ->
 get_sdk_version() -> "0.1.0".
 
 -spec get_sdk_type() -> list().
-get_sdk_type() -> "erlang".
+get_sdk_type() -> "erlang-server".

--- a/src/utils.erl
+++ b/src/utils.erl
@@ -6,8 +6,7 @@
 
 -spec get_timestamp() -> list().
 get_timestamp() ->
-  {Mega, Sec, Micro} = os:timestamp(),
-  integer_to_list((Mega * 1000000 + Sec) * 1000 + round(Micro / 1000)).
+  integer_to_list(os:system_time(millisecond)).
 
 
 -spec get_statsig_metadata() -> map().

--- a/test/consistency_test.erl
+++ b/test/consistency_test.erl
@@ -38,9 +38,14 @@ test_gate(Name, Gate, User) ->
       false;
     Name == <<"test_ua">> ->
       false;
+    Name == <<"test_time_on">> ->
+      false;
+    Name == <<"test_time_before">> ->
+      false;
     true ->
       Result = statsig:check_gate(User, Name),
       ServerResult = maps:get(<<"value">>, Gate, false),
+      
       ?assert(Result == ServerResult)
   end.
   


### PR DESCRIPTION
This is the first in a set of cleanup PRs for the erlang SDK, per feedback on https://github.com/statsig-io/erlang-sdk/commit/1f783f173137f31c6da1bc0822a643c2d2d5b8c1

The main change here is updating the api for statsig and making it into an application by hiding the (current) gen_server implementation.  This should make the move to ets cleaner and not a breaking change.

Along with that update, I cleaned up some imports and fixed a few issues pointed out.

Next up - replace the networking library, cleanup the if statements, and move to ets