### PR TITLE
Replace inets with hackney

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info, {src_dirs, ["src", "test"]}]}.
 {project_plugins, [rebar3_format, steamroller]}.
 {plugins, [rebar3_format, steamroller]}.
-{deps, [jiffy]}.
+{deps, [jiffy, hackney]}.
 {format, [
     {files, ["src/*.erl", "include/*.hrl"]},
     {ignore, ["src/*_ignore.erl", "src/ignored_file_config.erl"]},

--- a/src/logging.erl
+++ b/src/logging.erl
@@ -11,9 +11,9 @@ get_event(User, EventName, Value, Metadata) ->
       <<"user">> => User,
       <<"time">> => list_to_binary(utils:get_timestamp())
     },
-  if
-    Value == undefined -> Event;
-    true -> maps:put(<<"value">>, Value, Event)
+  case Value == undefined of
+    true -> Event;
+    _HasValue -> maps:put(<<"value">>, Value, Event)
   end.
 
 

--- a/src/network.erl
+++ b/src/network.erl
@@ -1,31 +1,27 @@
 -module(network).
 
--export([request/4]).
+-export([request/3]).
 
-request(ApiKey, Endpoint, Input, Sync) ->
-  Method = post,
+request(ApiKey, Endpoint, Input) ->
   URL = application:get_env(statsig, statsig_api, "https://statsigapi.net/v1/"),
-  Header =
+  Headers =
     [
-      {"STATSIG-API-KEY", ApiKey},
-      {"STATSIG-CLIENT-TIME", utils:get_timestamp()},
-      {"STATSIG-SDK-TYPE", utils:get_sdk_type()},
-      {"STATSIG-SDK-VERSION", utils:get_sdk_version()}
+      {<<"STATSIG-API-KEY">>, ApiKey},
+      % {"STATSIG-CLIENT-TIME", get_timestamp()},
+      % {"STATSIG-SDK-TYPE", get_sdk_type()},
+      % {"STATSIG-SDK-VERSION", get_sdk_version()},
+      {<<"Content-Type">>, <<"application/json">>}
     ],
-  Type = "application/json",
   maps:put(<<"statsigMetadata">>, utils:get_statsig_metadata(), Input),
   RequestBody = jiffy:encode(Input),
-  HTTPOptions = [],
-  Options = [{sync, Sync}],
-  case
-  httpc:request(Method, {URL ++ Endpoint, Header, Type, RequestBody}, HTTPOptions, Options) of
-    {ok, {{_, StatusCode, _}, _, Body}} ->
+  case hackney:post(URL ++ Endpoint, Headers, RequestBody, []) of
+    {ok, StatusCode, _RespHeaders, ClientRef} ->
       if
-        StatusCode < 300 -> Body;
+        StatusCode < 300 -> 
+          {ok, Body} = hackney:body(ClientRef),
+          Body;
         true -> false
       end;
-
-    {ok, _RequestId} -> true;
     {error, _} -> false;
     true -> false
   end.

--- a/src/network.erl
+++ b/src/network.erl
@@ -6,22 +6,25 @@ request(ApiKey, Endpoint, Input) ->
   URL = application:get_env(statsig, statsig_api, "https://statsigapi.net/v1/"),
   Headers =
     [
-      {<<"STATSIG-API-KEY">>, ApiKey},
-      % {"STATSIG-CLIENT-TIME", get_timestamp()},
-      % {"STATSIG-SDK-TYPE", get_sdk_type()},
-      % {"STATSIG-SDK-VERSION", get_sdk_version()},
-      {<<"Content-Type">>, <<"application/json">>}
+      {"STATSIG-API-KEY", ApiKey},
+      {"STATSIG-CLIENT-TIME", utils:get_timestamp()},
+      {"STATSIG-SDK-TYPE", utils:get_sdk_type()},
+      {"STATSIG-SDK-VERSION", utils:get_sdk_version()},
+      {"Content-Type", <<"application/json">>}
     ],
-  maps:put(<<"statsigMetadata">>, utils:get_statsig_metadata(), Input),
-  RequestBody = jiffy:encode(Input),
+  RequestBody = jiffy:encode(maps:put(<<"statsigMetadata">>, utils:get_statsig_metadata(), Input)),
+
   case hackney:post(URL ++ Endpoint, Headers, RequestBody, []) of
     {ok, StatusCode, _RespHeaders, ClientRef} ->
       if
         StatusCode < 300 -> 
           {ok, Body} = hackney:body(ClientRef),
           Body;
-        true -> false
+        true -> 
+          false
       end;
-    {error, _} -> false;
-    true -> false
+    {error, _} -> 
+      false;
+    true -> 
+      false
   end.

--- a/src/statsig.app.src
+++ b/src/statsig.app.src
@@ -6,8 +6,7 @@
   {applications,
    [kernel,
     stdlib,
-    inets,
-    ssl
+    hackney
    ]},
   {env,[{statsig_api, "https://statsigapi.net/v1/"}]},
   {modules, [gen_server]},

--- a/src/statsig_server.erl
+++ b/src/statsig_server.erl
@@ -49,7 +49,7 @@ handle_cast(
   flush,
   [{config_specs, _ConfigSpecs}, {log_events, Events}, {api_key, ApiKey}]
 ) ->
-  flush_events(api_key, Events),
+  flush_events(ApiKey, Events),
   {noreply, [{config_specs, _ConfigSpecs}, {log_events, []}, {api_key, ApiKey}]}.
 
 handle_info(_In, State) -> {noreply, State}.

--- a/src/statsig_server.erl
+++ b/src/statsig_server.erl
@@ -17,7 +17,7 @@ start_link(ApiKey) ->
   gen_server:start_link({local,?MODULE}, ?MODULE, [ApiKey], []).
 
 init([ApiKey]) ->
-  case network:request(ApiKey, "download_config_specs", #{}, true) of
+  case network:request(ApiKey, "download_config_specs", #{}) of
     false ->
       {stop, "Initialize Failed"};
     Body ->
@@ -96,7 +96,7 @@ handle_config(
   Config,
   [{config_specs, ConfigSpecs}, {log_events, Events}, {api_key, ApiKey}]
 ) ->
-  {_Rule, GateValue, JsonValue, RuleID, SecondaryExposures} =
+  {_Rule, _GateValue, JsonValue, RuleID, SecondaryExposures} =
     evaluator:eval_config(User, ConfigSpecs, Config),
   ConfigExposure =
     logging:get_exposure(
@@ -118,7 +118,7 @@ handle_config(
 
 flush_events(ApiKey, Events) ->
   Input = #{<<"events">> => Events},
-  network:request(ApiKey, "rgstr", Input, false) /= false.
+  network:request(ApiKey, "rgstr", Input) /= false.
 
 
 handle_events(Events, ApiKey) ->

--- a/src/utils.erl
+++ b/src/utils.erl
@@ -11,7 +11,7 @@ get_timestamp() ->
 
 -spec get_statsig_metadata() -> map().
 get_statsig_metadata() ->
-  #{<<"sdkType">> => get_sdk_type(), <<"sdkVersion">> => get_sdk_version()}.
+  #{<<"sdkType">> => list_to_binary(get_sdk_type()), <<"sdkVersion">> => list_to_binary(get_sdk_version())}.
 
 -spec get_sdk_version() -> list().
 get_sdk_version() -> "0.1.0".

--- a/test/consistency_test.erl
+++ b/test/consistency_test.erl
@@ -6,8 +6,9 @@ gate_test() ->
   ApiKey = os:getenv("test_api_key"),
   application:set_env(statsig, statsig_api_key, ApiKey),
   application:start(statsig),
-
-  Body = network:request(ApiKey, "rulesets_e2e_test", #{}, true),
+  {ok, _Apps} = application:ensure_all_started(statsig),
+  
+  Body = network:request(ApiKey, "rulesets_e2e_test", #{}),
   TestData =  maps:get(<<"data">>, jiffy:decode(Body, [return_maps]), []),
   lists:map(fun (Data) -> test_input(Data) end, TestData),
   statsig:log_event(#{<<"userID">> => <<"321">>}, <<"custom_event">>, 12, #{<<"test">> => <<"val">>}),

--- a/test/consistency_test.erl
+++ b/test/consistency_test.erl
@@ -4,16 +4,17 @@
 
 gate_test() ->
   ApiKey = os:getenv("test_api_key"),
-  application:set_env(statsig, statsig_api_key, ApiKey),
+  application:set_env(statsig, statsig_api_key, "secret-zNVRGSSd8iNoZL7RLb8S2zRNdl2a2HJmIagNstqReYc"),
   application:start(statsig),
   {ok, _Apps} = application:ensure_all_started(statsig),
   
   Body = network:request(ApiKey, "rulesets_e2e_test", #{}),
-  TestData =  maps:get(<<"data">>, jiffy:decode(Body, [return_maps]), []),
-  lists:map(fun (Data) -> test_input(Data) end, TestData),
-  statsig:log_event(#{<<"userID">> => <<"321">>}, <<"custom_event">>, 12, #{<<"test">> => <<"val">>}),
+  statsig:log_event(#{<<"userID">> => <<"321">>}, <<"newevent">>, 12, #{<<"test">> => <<"val">>}),
   statsig:log_event(#{<<"userID">> => <<"456">>}, <<"custom_event">>, <<"hello">>, #{<<"123">> => <<"444">>}),
   statsig:log_event(#{<<"userID">> => <<"12345">>}, <<"custom_event">>, #{<<"test">> => <<"val">>}),
+  statsig:flush(),
+  TestData =  maps:get(<<"data">>, jiffy:decode(Body, [return_maps]), []),
+  lists:map(fun (Data) -> test_input(Data) end, TestData),
   statsig:flush().
 
 test_input(Input) ->

--- a/test/consistency_test.erl
+++ b/test/consistency_test.erl
@@ -4,7 +4,7 @@
 
 gate_test() ->
   ApiKey = os:getenv("test_api_key"),
-  application:set_env(statsig, statsig_api_key, "secret-zNVRGSSd8iNoZL7RLb8S2zRNdl2a2HJmIagNstqReYc"),
+  application:set_env(statsig, statsig_api_key, ApiKey),
   application:start(statsig),
   {ok, _Apps} = application:ensure_all_started(statsig),
   


### PR DESCRIPTION
We can do what ExAws did later, by defining a behavior to plug and play your own preferred network class.  But for now, lets just use hackney.

Already seeing better performance with this - log event requests that used to fail during the test are now succeeding