### PR TITLE
Add polling for config spec changes

### DIFF
--- a/src/evaluator.erl
+++ b/src/evaluator.erl
@@ -530,7 +530,7 @@ get_unit_id(User, IdType) ->
     true ->
       UserID = maps:get(IdType, User, unknown),
       if
-        UserID == null -> <<"">>;
+        UserID == unknown -> <<"">>;
         true -> UserID
       end
   end.
@@ -543,9 +543,9 @@ compute_user_hash(Value) ->
 
 
 eval_pass_percent(User, Rule, ConfigSpec) ->
-  ConfigSalt = binary_to_list(maps:get(<<"salt">>, ConfigSpec, "")),
+  ConfigSalt = binary_to_list(maps:get(<<"salt">>, ConfigSpec, <<"">>)),
   RuleSalt =
-    binary_to_list(maps:get(<<"salt">>, Rule, maps:get(<<"id">>, Rule, ""))),
+    binary_to_list(maps:get(<<"salt">>, Rule, maps:get(<<"id">>, Rule, <<"">>))),
   IdType = maps:get(<<"idType">>, Rule, ""),
   UnitID = get_unit_id(User, IdType),
   Hash = compute_user_hash(ConfigSalt ++ "." ++ RuleSalt ++ "." ++ UnitID),

--- a/src/statsig.app.src
+++ b/src/statsig.app.src
@@ -9,9 +9,7 @@
     hackney
    ]},
   {env,[]},
-  {modules, [gen_server]},
   {modules, [gen_server, ets]},
-
   {licenses, ["ISC"]},
   {links, []}
  ]}.


### PR DESCRIPTION
```
rebar3 shell

application:set_env(statsig, statsig_api_key, "SERVER_SECRET").

application:start(statsig).

application:ensure_all_started(statsig).


4> statsig:check_gate(#{<<"userID">> => "123"}, <<"always_on_gate">>).
true
5> statsig:check_gate(#{}, <<"always_on_gate">>).
true

...
```

toggled gate off in console

```
15> statsig:check_gate(#{}, <<"always_on_gate">>).
true
16> statsig:check_gate(#{}, <<"always_on_gate">>).
false
17> statsig:check_gate(#{}, <<"always_on_gate">>).
false
18> statsig:check_gate(#{<<"userID">> => "123"}, <<"always_on_gate">>).
false
```

toggled to userid 123 -> pass 0%, everyone pass 100%

```
26> statsig:check_gate(#{}, <<"always_on_gate">>).
false
27> statsig:check_gate(#{}, <<"always_on_gate">>).
true
28> statsig:check_gate(#{}, <<"always_on_gate">>).
true
29> statsig:check_gate(#{<<"userID">> => "123"}, <<"always_on_gate">>).
false
30> statsig:check_gate(#{<<"userID">> => "456"}, <<"always_on_gate">>).
true
31> statsig:check_gate(#{<<"userID">> => "123"}, <<"always_on_gate">>).
false
32> statsig:check_gate(#{<<"userID">> => "123"}, <<"always_on_gate">>).
false
33> statsig:check_gate(#{}, <<"always_on_gate">>).
true
```