### PR TITLE
Fixes the syncing of events

### DIFF
--- a/src/statsig_server.erl
+++ b/src/statsig_server.erl
@@ -1,5 +1,7 @@
 -module(statsig_server).
 
+-include_lib("kernel/include/logger.hrl").
+
 -behaviour(gen_server).
 
 -export(
@@ -89,9 +91,9 @@ handle_info(handle_events, [{log_events, Events}, {api_key, ApiKey}, {last_sync_
 
 handle_info(flush, [{log_events, Events}, {api_key, ApiKey}, {last_sync_time, Time}]) ->
   Unsent = handle_events(Events, ApiKey),
-  {noreply, [{log_events, Unsent}, {api_key, ApiKey}, {last_sync_time, Time}]};
+  {noreply, [{log_events, Unsent}, {api_key, ApiKey}, {last_sync_time, Time}]}.
 
-handle_info(_In, State) -> {noreply, State}.
+% handle_info(_In, State) -> {noreply, State}.
 
 handle_call({flush}, _From, [{log_events, Events}, {api_key, ApiKey}, {last_sync_time, Time}]) ->
   Unsent = handle_events(Events, ApiKey),

--- a/src/statsig_server.erl
+++ b/src/statsig_server.erl
@@ -80,6 +80,13 @@ handle_info(download_specs, [{log_events, Events}, {api_key, ApiKey}, {last_sync
   erlang:send_after(Delay, self(), download_specs),
   {noreply, [{log_events, Events}, {api_key, ApiKey}, {last_sync_time, Time}]};
 
+handle_info(handle_events, [{log_events, Events}, {api_key, ApiKey}, {last_sync_time, Time}]) ->
+  Unsent = handle_events(Events, ApiKey),
+  FlushDelay = application:get_env(statsig, statsig_flush_interval, 60000),
+  erlang:send_after(FlushDelay, self(), handle_events),
+  {noreply, [{log_events, Unsent}, {api_key, ApiKey}, {last_sync_time, Time}]};
+
+
 handle_info(flush, [{log_events, Events}, {api_key, ApiKey}, {last_sync_time, Time}]) ->
   Unsent = handle_events(Events, ApiKey),
   {noreply, [{log_events, Unsent}, {api_key, ApiKey}, {last_sync_time, Time}]};

--- a/src/statsig_server.erl
+++ b/src/statsig_server.erl
@@ -1,7 +1,5 @@
 -module(statsig_server).
 
--include_lib("kernel/include/logger.hrl").
-
 -behaviour(gen_server).
 
 -export(

--- a/src/statsig_server.erl
+++ b/src/statsig_server.erl
@@ -91,9 +91,9 @@ handle_info(handle_events, [{log_events, Events}, {api_key, ApiKey}, {last_sync_
 
 handle_info(flush, [{log_events, Events}, {api_key, ApiKey}, {last_sync_time, Time}]) ->
   Unsent = handle_events(Events, ApiKey),
-  {noreply, [{log_events, Unsent}, {api_key, ApiKey}, {last_sync_time, Time}]}.
+  {noreply, [{log_events, Unsent}, {api_key, ApiKey}, {last_sync_time, Time}]};
 
-% handle_info(_In, State) -> {noreply, State}.
+handle_info(_In, State) -> {noreply, State}.
 
 handle_call({flush}, _From, [{log_events, Events}, {api_key, ApiKey}, {last_sync_time, Time}]) ->
   Unsent = handle_events(Events, ApiKey),


### PR DESCRIPTION
Fixes the genserver that doesn't handle the scheduling of the flushing events to statsig's api.
The `send_after` call was being ignored or caught in the `handle_info` catch-all function.
This PR adds the function to handle calls sent to the process with the atom `handle_events`, and then reschedules another call after FlushDelay millisecons